### PR TITLE
Fix grammar on mekanism induction matrix page.

### DIFF
--- a/docs/peripheralproxy/mekanism/induction.md
+++ b/docs/peripheralproxy/mekanism/induction.md
@@ -4,7 +4,7 @@
     ![Header](https://srendi.de/wp-content/uploads/2021/05/Induction-Port.png){ align=right }
     Mod: Mekanism <br><br/>
     Block: Induction Valve
-The [Induction Matrix](https://wiki.aidancbrady.com/wiki/Induction_Matrix) is a multiblock structure from mekanism to store almost infinite amounts of energy.
+The [Induction Matrix](https://wiki.aidancbrady.com/wiki/Induction_Matrix) is a multiblock structure from mekanism made to store large amounts of energy.
 
 <br><br/>
 <br><br/>


### PR DESCRIPTION
The grammar was slightly off, as was the description. The Induction Matrix is made to store large amounts of energy, yes, but no where near infinite.