### PR TITLE
Add overview to peripheral pages, update examples

### DIFF
--- a/docs/peripherals/ar_controller.md
+++ b/docs/peripherals/ar_controller.md
@@ -1,4 +1,5 @@
-#AR Controller
+# AR Controller
+
 !!! picture inline end
     ![Header](https://srendi.de/wp-content/uploads/2021/04/AR-Controller.png){ align=right }
 
@@ -7,34 +8,45 @@ The AR Controller is used to control your AR Goggles wirelessly. You can draw an
 !!! hint
     To link your goggles to an AR Controller, right click it with them in your hand. Multiple Goggles can be linked to one Controller.
 
-##Functions
+<br>
+
+## Overview
+
+| Peripheral Name | Interfaces with | Events | Introduced in |
+| --------------- | --------------- | ------ | ------------- |
+| arController    | AR Goggles      | No     | 0.5b          |
+
+## Functions
+
 While the Controller is in relative mode, it interprets all coordinates as if they were on a virtual screen the size you specified, and then scales them according to your screen size.
 
-All color values are hexadecimal color codes (for example ```0xff00ff```)
+All color values are hexadecimal color codes (for example `0xff00ff`)
 
-| Function | Returns  | Description |
-|------------|--------------|-------------|
-| isRelativeMode()  | boolean\[, int, int\] | Returns true and the size of the virtual screen if relative mode is active, or just false if it isn't. |
-| setRelativeMode(boolean enabled\[, int virtualScreenWidth, int virtualScreenHeight\])  | | Activates or deactivates relative mode. Requires virtual screen width and height if it's being enabled. |
-| drawString(string text, int x, int y, int color) | | Draws the given string to the specified position and the specified color. |
-| drawCenteredString(string text, int x, int y, int color) | | The same as ```drawString()```, but centers the string horizontally around the specified position. |
-| drawRightboundString(string text, int x, int y, int color) | | The same as ```drawString()```, but the string is positioned with its right end at the specified position. |
-| drawCircle(int x, int y, int radius, int color) | | Draws a circle without filling it.  |
-| drawItemIcon(string itemId, int x, int y) | | Draws the given item to the specified position. |
-| horizontalLine(int minX, int maxX, int y, int color) | | Draws a horizontal line in the given color from minX to maxX at vertical y. |
-| verticalLine(int x, int minY, int maxY, int color) | | Draws a vertical line in the given color from minY to maxY at horizontal x. |
-| fill(int minX, int minY, int maxX, int maxY, int color) | | Fills a rectangle with the given color from the corner minX, minY to maxX, maxY. |
-| fillGradient(int minX, int minY, int maxX, int maxY, int colorFrom, int colorTo) | | Draws a rectangular gradient from colorFrom to colorTo with the given corners. |
-| fillCircle(int x, int y, int radius, int color) | | Draws a full circle. |
-| clear() | | Clears the entire canvas. |
+| Function                                                                              | Returns               | Description                                                                                             |
+| ------------------------------------------------------------------------------------- | --------------------- | ------------------------------------------------------------------------------------------------------- |
+| clear()                                                                               |                       | Clears the entire canvas.                                                                               |
+| drawCenteredString(string text, int x, int y, int color)                              |                       | The same as `drawString()`, but centers the string horizontally around the specified position.          |
+| drawCircle(int x, int y, int radius, int color)                                       |                       | Draws a circle without filling it.                                                                      |
+| drawItemIcon(string itemId, int x, int y)                                             |                       | Draws the given item to the specified position.                                                         |
+| drawRightboundString(string text, int x, int y, int color)                            |                       | The same as `drawString()`, but the string is positioned with its right end at the specified position.  |
+| drawString(string text, int x, int y, int color)                                      |                       | Draws the given string to the specified position and the specified color.                               |
+| fill(int minX, int minY, int maxX, int maxY, int color)                               |                       | Fills a rectangle with the given color from the corner minX, minY to maxX, maxY.                        |
+| fillCircle(int x, int y, int radius, int color)                                       |                       | Draws a full circle.                                                                                    |
+| fillGradient(int minX, int minY, int maxX, int maxY, int colorFrom, int colorTo)      |                       | Draws a rectangular gradient from colorFrom to colorTo with the given corners.                          |
+| horizontalLine(int minX, int maxX, int y, int color)                                  |                       | Draws a horizontal line in the given color from minX to maxX at vertical y.                             |
+| isRelativeMode()                                                                      | boolean\[, int, int\] | Returns true and the size of the virtual screen if relative mode is active, or just false if it isn't.  |
+| setRelativeMode(boolean enabled\[, int virtualScreenWidth, int virtualScreenHeight\]) |                       | Activates or deactivates relative mode. Requires virtual screen width and height if it's being enabled. |
+| verticalLine(int x, int minY, int maxY, int color)                                    |                       | Draws a vertical line in the given color from minY to maxY at horizontal x.                             |
 
-Everything that's painted onto the canvas remains there until ```clear()``` is called, however, it might be repositioned if relative mode is toggled on or off.
+Everything that's painted onto the canvas remains there until `clear()` is called, however, it might be repositioned if relative mode is toggled on or off.
 
 !!! hint
     Use negative coordinates to specify an x value from the right end of the screen or a y value from the bottom!
 
-##Example
+## Example
+
 Olfi01 made a simple script that shows the current date and time in the top right corner of the screen and updates every second.
+
 ```lua
 controller = peripheral.wrap("left") -- Defines the controller to the left of the computer
 controller.setRelativeMode(true, 1600, 900) -- Convenient Aspect ratio for most screens
@@ -60,7 +72,8 @@ And we have another script which depends on the script above, but is simpler to 
 
 Script: [Github](https://gist.github.com/Seniorendi/954e9888fac01efe8f23e82d0ae06e92)
 
-##Changelog/Trivia
+## Changelog/Trivia
+
 0.5.2b
 Added fillCircle, drawCircle and drawItemIcon.
 

--- a/docs/peripherals/ar_controller.md
+++ b/docs/peripherals/ar_controller.md
@@ -48,7 +48,10 @@ Everything that's painted onto the canvas remains there until `clear()` is calle
 Olfi01 made a simple script that shows the current date and time in the top right corner of the screen and updates every second.
 
 ```lua
-controller = peripheral.wrap("left") -- Defines the controller to the left of the computer
+local controller = peripheral.find("arController") -- Finds the peripheral if one is connected
+
+if controller == nil then error("arController not found") end
+
 controller.setRelativeMode(true, 1600, 900) -- Convenient Aspect ratio for most screens
 while true do
   local timer = os.startTimer(1)

--- a/docs/peripherals/chat_box.md
+++ b/docs/peripherals/chat_box.md
@@ -47,9 +47,9 @@ You don't have to `.wrap()` or `.find()` the peripheral (unless you intend to se
 The Chat Box is quite easy to use. Wrap the peripheral and send messages or use the chat event.
 
 ```lua
-local box = peripheral.find("chatBox") -- Finds a connected Chat Box
+local box = peripheral.find("chatBox") -- Finds the peripheral if one is connected
 
-if box == nil then error("Missing Chat Box") end
+if box == nil then error("chatBox not found") end
 
 box.sendMessage("Hey world") -- Sends a message to the global chat
 box.sendMessageToPlayer("Hey you", "Player644") -- Send a message only to one specific player

--- a/docs/peripherals/chat_box.md
+++ b/docs/peripherals/chat_box.md
@@ -1,4 +1,5 @@
 # Chat Box
+
 !!! picture inline end
     ![Header](https://srendi.de/wp-content/uploads/2021/04/Chat-box.png){ align=right }
 
@@ -12,18 +13,18 @@ The Chat Box is able to read and write messages to the in-game chat. You can sen
 ## Overview
 
 | Peripheral Name | Interfaces with | Events | Introduced in |
-|-----------------|-----------------|--------|---------------|
+| --------------- | --------------- | ------ | ------------- |
 | chatBox         | Game Chat       | Yes    | 0.1b          |
 
 ## Events
 
 | Event Name | Parameter One | Parameter Two   | Parameter Three | Description                         |
-|------------|---------------|-----------------|-----------------|-------------------------------------|
-|chat        | "chat"        | string username | string message  | Fires when a player sends a message |
+| ---------- | ------------- | --------------- | --------------- | ----------------------------------- |
+| chat       | "chat"        | string username | string message  | Fires when a player sends a message |
 
 ### Example
 
-``` lua
+```lua
 while true do
   event, username, message = os.pullEvent("chat") -- Will be fired when someone sends a chat message
   print(username.. " just wrote: ".. message) -- Prints "*User* just wrote: *Message*"
@@ -31,21 +32,21 @@ end
 ```
 
 !!! info
-    The `chat` event will fire once a chatbox has been connected to the computer.
-    You don't have to `.wrap()` or `.find()` the peripheral (unless you intend to send messages).
+The `chat` event will fire once a chatbox has been connected to the computer.
+You don't have to `.wrap()` or `.find()` the peripheral (unless you intend to send messages).
 
 ## Functions
 
-| Function | Returns  | Description |
-|------------|--------------|-------------|
-| sendMessage(string message)  | | Broadcasts a message to the global chat. |
-| sendMessageToPlayer(string message, string username)  | | Sends a message to one specific player. |
+| Function                                             | Returns | Description                              |
+| ---------------------------------------------------- | ------- | ---------------------------------------- |
+| sendMessage(string message)                          |         | Broadcasts a message to the global chat. |
+| sendMessageToPlayer(string message, string username) |         | Sends a message to one specific player.  |
 
 ### Example
 
 The Chat Box is quite easy to use. Wrap the peripheral and send messages or use the chat event.
 
-``` lua
+```lua
 local box = peripheral.find("chatBox") -- Finds a connected Chat Box
 
 if box == nil then error("Missing Chat Box") end

--- a/docs/peripherals/energy_detector.md
+++ b/docs/peripherals/energy_detector.md
@@ -24,7 +24,9 @@ The Energy Detector is quite simple, you can set the max energy flow or receive 
 Example:
 
 ```lua
-detector = peripheral.wrap("energyDetector_0") -- Define the peripheral
+local detector = peripheral.find("energyDetector") -- Finds the peripheral if one is connected
+
+if detector == nil then error("energyDetector not found") end
 
 detector.setTransferRateLimit(512) -- Only 512 FE/t can go through the block
 print("Current transfer rate: ".. detector.getTransferRate .." FE/t") -- prints the current transfer rate

--- a/docs/peripherals/energy_detector.md
+++ b/docs/peripherals/energy_detector.md
@@ -1,4 +1,5 @@
-#Energy Detector
+# Energy Detector
+
 !!! picture inline end
     ![Header](https://srendi.de/wp-content/uploads/2021/04/Energy-Detector.png){ align=right }
 
@@ -8,11 +9,15 @@ The Energy Detector can detect energy flow and acts as a resistor. You can defin
     The Energy Detector does not work on versions below 0.4.5b.
     I recommend to use the latest version.
 
-##Events
+<br>
 
-No Events
+## Overview
 
-##Functions
+| Peripheral Name | Interfaces with | Events | Introduced in |
+| --------------- | --------------- | ------ | ------------- |
+| energyDetector  | RF              | No     | 0.4.1b        |
+
+## Functions
 
 The Energy Detector is quite simple, you can set the max energy flow or receive the current flow/max flow.
 
@@ -25,19 +30,19 @@ detector.setTransferRateLimit(512) -- Only 512 FE/t can go through the block
 print("Current transfer rate: ".. detector.getTransferRate .." FE/t") -- prints the current transfer rate
 ```
 
-| Function | Returns | Description |
-|----------|---------|-------------|
-| setTransferRateLimit(int limit) | | Set the transfer rate limit. |
-| getTransferRateLimit() | int | Returns the max rate limit which has been set with setTransferRateLimit(). |
-| getTransferRate() | int | Returns the current energy which go through the block. |
+| Function                        | Returns | Description                                                                |
+| ------------------------------- | ------- | -------------------------------------------------------------------------- |
+| getTransferRate()               | int     | Returns the current energy which go through the block.                     |
+| getTransferRateLimit()          | int     | Returns the max rate limit which has been set with setTransferRateLimit(). |
+| setTransferRateLimit(int limit) |         | Set the transfer rate limit.                                               |
 
-##Changelog/Trivia
+## Changelog/Trivia
 
 The Energy Detector had some weird problems in versions older than 0.4.6b
 The block was able to store infinite amounts of energy or it creates an limitless amount of energy.
 
 0.4.6b
-The energy detector is now bug free. *hopefully*
+The energy detector is now bug free. _hopefully_
 
 0.4.5b
 Completly changed the system of the energy detector, but the energy detector was able to drain energy without any reson.

--- a/docs/peripherals/environment_detector.md
+++ b/docs/peripherals/environment_detector.md
@@ -1,30 +1,37 @@
-#Environment Detector
+# Environment Detector
+
 !!! picture inline end
     ![Header](https://srendi.de/wp-content/uploads/2021/04/Environment-Detector.png){ align=right }
 
-The Environment Detector is able to receive information from the environment like the current time, the current moon phase,
+The Environment Detector provides current information from the environment like the current time, the current moon phase,
 the light level of the block and many more.
 
-##Events
+## Overview
+
+| Peripheral Name     | Interfaces with | Events | Introduced in |
+| ------------------- | --------------- | ------ | ------------- |
+| environmentDetector | World           | No     | 0.1b          |
+
+## Events
+
 No Events
 
-
-##Functions
+## Functions
 
 List of moon phases:
 
-* 0 Full moon
-* 1 Waning gibbous
-* 2 Third quarter
-* 3 Wanning crescent
-* 4 New moon
-* 5 Waxing crescent
-* 6 First quarter
-* 7 Waxing gibbous
+-   0 Full moon
+-   1 Waning gibbous
+-   2 Third quarter
+-   3 Wanning crescent
+-   4 New moon
+-   5 Waxing crescent
+-   6 First quarter
+-   7 Waxing gibbous
 
 The Environment Detector is easy to use. Wrap the peripheral and use one of the functions.
 
-``` lua
+```lua
 detector = peripheral.wrap("right") --Defines the detector on the right
 
 --Prints some information to the terminal of the computer
@@ -35,30 +42,30 @@ print("Current dimension ".. detector.getDimensionName())
 
 ```
 
-| Function | Returns | Description |
-|----------|---------|-------------|
-|getBiome() |	String | Returns the biome the block is in. |
-|getSkyLightLevel()	| int |	Returns the sky light level above the block. |
-|getBlockLightLevel() |	int |	Returns the light level of the block (can be manipulated with light sources). |
-|getDayLightLevel()	| int |	Returns the day light level of the current world from 0 to 15 (like the day light sensor). |
-|getTime() (WIP) | int | Returns the daytime of the current world. |
-|getDimensionProvider()	| string | Returns the provider of the dimension (ex. minecraft). |
-|getDimensionName() |	string | Returns the name of the dimension (ex. the_nether). |
-|getDimensionPaN() | string |	Returns the name with the provider of the dimension (ex. minecraft:overworld). |
-|getMoonName() | string |	Returns the current moon phase as name (ex. Third quarter). |
-|getMoonId() | int | Returns the current moon phase as id (ex. 2). |
-|getRadiation() | table | Returns the current radiation from mekanism. |
-|isSlimeChunk() | boolean |	Returns true if the chunk is a slime chunk. |
-|isDimension(string dimension) | boolean | Returns true if the current dimension matches the first parameter. |
-|isMoon(int moonphase) | boolean | Returns true if the current moon phase matches the first parameter (ex. 0 = Full moon). |
-|isRaining() | boolean | Returns true if it's raining. |
-|isThunder() | boolean | Returns true if it's thundering. |
-|isSunny() | boolean | Returns true if it's sunny. |
-|listDimensions() |	table |	Returns a table with all registered dimensions(also modded dimensions). |
-|getRadiation() |	table |	Returns the radiation of mekanism with the unit. |
-|getRadiationRaw() | int |	Returns the raw radiation without unit. |
+| Function                      | Returns | Description                                                                                |
+| ----------------------------- | ------- | ------------------------------------------------------------------------------------------ |
+| getBiome()                    | string  | Returns the biome the block is in.                                                         |
+| getBlockLightLevel()          | int     | Returns the light level of the block (can be manipulated with light sources).              |
+| getDayLightLevel()            | int     | Returns the day light level of the current world from 0 to 15 (like the day light sensor). |
+| getDimensionName()            | string  | Returns the name of the dimension (ex. the_nether).                                        |
+| getDimensionPaN()             | string  | Returns the name with the provider of the dimension (ex. minecraft:overworld).             |
+| getDimensionProvider()        | string  | Returns the provider of the dimension (ex. minecraft).                                     |
+| getMoonId()                   | int     | Returns the current moon phase as id (ex. 2).                                              |
+| getMoonName()                 | string  | Returns the current moon phase as name (ex. Third quarter).                                |
+| getRadiation()                | table   | Returns the current radiation from mekanism.                                               |
+| getRadiation()                | table   | Returns the radiation of mekanism with the unit.                                           |
+| getRadiationRaw()             | int     | Returns the raw radiation without unit.                                                    |
+| getSkyLightLevel()            | int     | Returns the sky light level above the block.                                               |
+| getTime() (WIP)               | int     | Returns the daytime of the current world.                                                  |
+| isDimension(string dimension) | boolean | Returns true if the current dimension matches the first parameter.                         |
+| isMoon(int moonphase)         | boolean | Returns true if the current moon phase matches the first parameter (ex. 0 = Full moon).    |
+| isRaining()                   | boolean | Returns true if it's raining.                                                              |
+| isSlimeChunk()                | boolean | Returns true if the chunk is a slime chunk.                                                |
+| isSunny()                     | boolean | Returns true if it's sunny.                                                                |
+| isThunder()                   | boolean | Returns true if it's thundering.                                                           |
+| listDimensions()              | table   | Returns a table with all registered dimensions(also modded dimensions).                    |
 
-##Changelog/Trivia
+## Changelog/Trivia
 
 0.6.5b
 Added getRadiationRaw

--- a/docs/peripherals/environment_detector.md
+++ b/docs/peripherals/environment_detector.md
@@ -30,7 +30,9 @@ List of moon phases:
 The Environment Detector is easy to use. Wrap the peripheral and use one of the functions.
 
 ```lua
-detector = peripheral.wrap("right") --Defines the detector on the right
+local detector = peripheral.find("environmentDetector") -- Finds the peripheral if one is connected
+
+if detector == nil then error("environmentDetector not found") end
 
 --Prints some information to the terminal of the computer
 print("Biome ".. detector.getBiome())

--- a/docs/peripherals/environment_detector.md
+++ b/docs/peripherals/environment_detector.md
@@ -6,15 +6,13 @@
 The Environment Detector provides current information from the environment like the current time, the current moon phase,
 the light level of the block and many more.
 
+<br><br><br><br><br><br>
+
 ## Overview
 
 | Peripheral Name     | Interfaces with | Events | Introduced in |
 | ------------------- | --------------- | ------ | ------------- |
 | environmentDetector | World           | No     | 0.1b          |
-
-## Events
-
-No Events
 
 ## Functions
 

--- a/docs/peripherals/inventory_manager.md
+++ b/docs/peripherals/inventory_manager.md
@@ -1,4 +1,5 @@
-#Inventory Manager
+# Inventory Manager
+
 !!! picture inline end
     ![Header](https://srendi.de/wp-content/uploads/2021/04/Inventory-Manager.png){ align=right }
 
@@ -7,9 +8,15 @@ The Inventory Manager can communicate with the player's inventory. You need to r
 !!! info
     Only one Memory Card can be linked by Inventory Manager.
 
-<br><br/>
+<br><br>
 
-##Functions
+## Overview
+
+| Peripheral Name  | Interfaces with  | Events | Introduced in |
+| ---------------- | ---------------- | ------ | ------------- |
+| inventoryManager | Player Inventory | No     | 0.5b          |
+
+## Functions
 
 ```lua
 manager = peripheral.wrap("back") --Wraps the Inventory Manager
@@ -21,17 +28,18 @@ manager.removeItemFromPlayer("UP", 114, "minecraft:stone") --Will remove 114 sto
 manager.removeItemFromPlayer("UP", 400) --Will remove 400 items from the players inventory to the chest above
 ```
 
-| Function | Returns  | Description |
-|------------|--------------|-------------|
-| getOwner()  | string | Returns the owner of the memory card, nil if the memory card is empty. |
-| addItemToPlayer(string inventoryBlock, int count\[, string item\])  | int amount | Adds an item to the player's inventory. `inventoryBlock` is the direction for the chest/inventory block. The Inventory Manager will add a random item to the player's inventory if the argument `item` is null. |
+| Function                                                                | Returns    | Description                                                                                                                                                                                                                                                |
+| ----------------------------------------------------------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| addItemToPlayer(string inventoryBlock, int count\[, string item\])      | int amount | Adds an item to the player's inventory. `inventoryBlock` is the direction for the chest/inventory block. The Inventory Manager will add a random item to the player's inventory if the argument `item` is null.                                            |
+| getArmor()                                                              | table      | Returns the content of the player's armor slots.                                                                                                                                                                                                           |
+| getItems()                                                              | table      | Returns the content of the player's inventory.                                                                                                                                                                                                             |
+| getOwner()                                                              | string     | Returns the owner of the memory card, nil if the memory card is empty.                                                                                                                                                                                     |
+| isPlayerEquipped()                                                      | boolean    | Returns true if the player is wearing one or more armor pieces.                                                                                                                                                                                            |
+| isWearing(int slot)                                                     | boolean    | Returns true if the player is wearing a armor piece on the given slot. Slots: 103(Helmet)-100(Boots)                                                                                                                                                       |
 | removeItemFromPlayer(string inventoryBlock, int count\[, string item\]) | int amount | Removes an item from the player's inventory to the given inventory direction. `inventoryBlock` is the direction for the chest/inventory block. The Inventory Manager will remove a random item from the player's inventory if the argument `item` is null. |
-| getItems() | table | Returns the content of the player's inventory. |
-| getArmor() | table | Returns the content of the player's armor slots. |
-| isPlayerEquipped() | boolean | Returns true if the player is wearing one or more armor pieces. |
-| isWearing(int slot) | boolean | Returns true if the player is wearing a armor piece on the given slot. Slots: 103(Helmet)-100(Boots) |
 
-##Changelog/Trivia
+## Changelog/Trivia
+
 0.5.2b
 Fixed a bug, that the inventory manager does not drop the contents.
 

--- a/docs/peripherals/inventory_manager.md
+++ b/docs/peripherals/inventory_manager.md
@@ -19,7 +19,9 @@ The Inventory Manager can communicate with the player's inventory. You need to r
 ## Functions
 
 ```lua
-manager = peripheral.wrap("back") --Wraps the Inventory Manager
+local manager = peripheral.find("inventoryManager") -- Finds the peripheral if one is connected
+
+if manager == nil then error("inventoryManager not found") end
 
 manager.addItemToPlayer("UP", 63, "minecraft:dirt") --Will add 63 dirt to the players inventory from the chest above
 

--- a/docs/peripherals/me_bridge.md
+++ b/docs/peripherals/me_bridge.md
@@ -1,21 +1,28 @@
-#ME Bridge
+# ME Bridge
 !!! picture inline end
     ![Header](https://srendi.de/wp-content/uploads/2021/04/ME-Bridge.png){ align=right }
 
 The Me Bridge is able to interact with Applied Energistics 2.
 You can retrieve items, craft items, get all items as a list and more. The Me Bridge uses one channel.
 
-##Events
+<br><br><br><br><br><br>
+
+## Overview
+
+| Peripheral Name | Interfaces with                 | Events | Introduced in |
+| --------------- | ------------------------------- | ------ | ------------- |
+| meBridge        | Applied Energistics 2 ME System | Yes    | 0.3b          |
+
+## Events
 
 !!! warning
-    The crafting event does not work everytime. The crafting event is also barely tested.
+The crafting event does not work everytime. The crafting event is also barely tested.
 
-| Event Name | Parameter One | Parameter Two | Description |
-|------------|---------------|---------------|-------------|
-| crafting | "crafting" | table job informations or nil | Fires when a crafting job is done, cancelled or aborted. |
+| Event Name | Parameter One | Parameter Two                 | Description                                              |
+| ---------- | ------------- | ----------------------------- | -------------------------------------------------------- |
+| crafting   | "crafting"    | table job informations or nil | Fires when a crafting job is done, cancelled or aborted. |
 
-
-##Functions
+## Functions
 
 Most functions uses a table to craft, export or import the item. You can see how these item parameters exactly works at the [Item parameters of the ME/RS Bridge](https://docs.srendi.de/othersandutilities/item_parameter/) page.
 
@@ -28,25 +35,25 @@ bridge.exportItem({name="minecraft:enchanted_book", count=1, nbt="ae70053c97f877
 -- Exports an protection I book to the chest above the me bridge.
 ```
 
-| Function | Returns | Description |
-|----------|---------|-------------|
-| listCraftableFluid() | table | Returns all craftable fluids. |
-| listFluid()	| table | Returns all stored fluids.
-| listCraftableItems() | table |	Returns all craftable items. |
-| listItems() |	table | Returns all items. |
-| isItemCrafting(table item) | boolean | Returns true if a job for the item already exists. |
-| getItem(table item) | table | Returns a table with information of the item. |
-| getEnergyUsage() | int |	Returns the energy usage of the whole ME System. |
-| getEnergyStorage() | int |	Returns the stored energy of the whole ME System. |
-| getMaxEnergyStorage() |	int | Returns the maximum energy storage of the whole ME System. |
-| getCraftingCPUs() |	table | Returns all connected crafting cpus. |
-| craftItem(table item)	| table | Crafts an item. |
-| exportItem(table item, string directions) |	int | Exports an item to a chest in the direction of the block. Valid directions are "up", "down", "north", "west", "east" and "south". |
-| importItem(table item, string directions) |	int | Imports an item to the Me System from the chest in the direction of the block. Valid directions are "up", "down", "north", "west", "east" and "south". |
-| exportItemToChest(table item, string chest) |	int |	Exports an item to a chest (every inventory tile entity should work) which is connected to the peripheral network. |
-| importItemFromChest(table item, string chest) |	int |	Imports an item to a chest (every inventory tile entity should work) which is connected to the peripheral network. |
+| Function                                      | Returns | Description                                                                                                                                            |
+| --------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| craftItem(table item)                         | table   | Crafts an item.                                                                                                                                        |
+| exportItem(table item, string directions)     | int     | Exports an item to a chest in the direction of the block. Valid directions are "up", "down", "north", "west", "east" and "south".                      |
+| exportItemToChest(table item, string chest)   | int     | Exports an item to a chest (every inventory tile entity should work) which is connected to the peripheral network.                                     |
+| getCraftingCPUs()                             | table   | Returns all connected crafting cpus.                                                                                                                   |
+| getEnergyStorage()                            | int     | Returns the stored energy of the whole ME System.                                                                                                      |
+| getEnergyUsage()                              | int     | Returns the energy usage of the whole ME System.                                                                                                       |
+| getItem(table item)                           | table   | Returns a table with information of the item.                                                                                                          |
+| getMaxEnergyStorage()                         | int     | Returns the maximum energy storage of the whole ME System.                                                                                             |
+| importItem(table item, string directions)     | int     | Imports an item to the Me System from the chest in the direction of the block. Valid directions are "up", "down", "north", "west", "east" and "south". |
+| importItemFromChest(table item, string chest) | int     | Imports an item to a chest (every inventory tile entity should work) which is connected to the peripheral network.                                     |
+| isItemCrafting(table item)                    | boolean | Returns true if a job for the item already exists.                                                                                                     |
+| listCraftableFluid()                          | table   | Returns all craftable fluids.                                                                                                                          |
+| listCraftableItems()                          | table   | Returns all craftable items.                                                                                                                           |
+| listFluid()                                   | table   | Returns all stored fluids.                                                                                                                             |
+| listItems()                                   | table   | Returns all items.                                                                                                                                     |
 
-##Screenshots
+## Screenshots
 
 Picture of the table from listItems()
 
@@ -60,8 +67,7 @@ Picture of the table from craftItem()
 
 ![Picture](https://srendi.de/wp-content/uploads/2021/02/Bild_2021-02-05_233210.png)
 
-
-##Example
+## Example
 
 I made a script to craft items, the computer will re-craft every item needed (a specified amount) in the ME system. Everything is adjustable.
 
@@ -73,7 +79,7 @@ Script: [Click here](https://gist.github.com/Seniorendi/dbbe08502ce51d59173c3b5e
 Screenshot:
 ![Picture](https://srendi.de/wp-content/uploads/2021/02/Bild_2021-02-05_233338.png)
 
-##Changelog/Trivia
+## Changelog/Trivia
 
 0.4b
 Reworked the system of the ME Bridge, it has now more features and a new system for the item parameter.

--- a/docs/peripherals/me_bridge.md
+++ b/docs/peripherals/me_bridge.md
@@ -29,7 +29,9 @@ Most functions uses a table to craft, export or import the item. You can see how
 Example with exportItem:
 
 ```lua
-bridge = peripheral.wrap("meBridge_0") -- Define the peripheral
+local bridge = peripheral.find("meBridge") -- Finds the peripheral if one is connected
+
+if manager == nil then error("meBridge not found") end
 
 bridge.exportItem({name="minecraft:enchanted_book", count=1, nbt="ae70053c97f877de546b0248b9ddf525"}, "UP")
 -- Exports an protection I book to the chest above the me bridge.

--- a/docs/peripherals/player_detector.md
+++ b/docs/peripherals/player_detector.md
@@ -24,8 +24,9 @@ The Player Detector is able to recognize players within a certain range. In addi
 Example:
 
 ```lua
-detector = peripheral.wrap("right") --Defines the Detector on the right
+local detector = peripheral.find("playerDetector") -- Finds the peripheral if one is connected
 
+if detector == nil then error("playerDetector not found") end
 
 function getPlayers(int range)
   local players = detector.getPlayersInRange(range) --Returns a table of every player in a certain range

--- a/docs/peripherals/player_detector.md
+++ b/docs/peripherals/player_detector.md
@@ -1,13 +1,20 @@
-#Player Detector
+# Player Detector
+
 !!! picture inline end
     ![Header](https://srendi.de/wp-content/uploads/2021/04/Player-Detector.png){ align=right }
 
 The Player Detector is able to recognize players within a certain range. In addition, it recognizes the player who clicks on him.
 
-##Events
+## Overview
 
-| Event Name | Parameter One  | Parameter Two | Description |
-|------------|--------------|-------------|-------------|
+| Peripheral Name | Interfaces with | Events | Introduced in |
+| --------------- | --------------- | ------ | ------------- |
+| playerDetector  | Players         | Yes    | 0.1b          |
+
+## Events
+
+| Event Name  | Parameter One | Parameter Two   | Description                              |
+| ----------- | ------------- | --------------- | ---------------------------------------- |
 | playerClick | "playerClick" | string username | Fires when a player clicks on the block. |
 
 ##Functions
@@ -43,17 +50,17 @@ while true do
 end
 ```
 
-| Function | Returns | Description |
-|----------|---------|-------------|
-| getPlayersInRange(int range) | table | Return players within a certain range. |
-| getPlayerPos(string player) | table | Returns player's position. |
+| Function                                    | Returns | Description                                           |
+| ------------------------------------------- | ------- | ----------------------------------------------------- |
+| getPlayersInRange(int range)                | table   | Return players within a certain range.                |
+| getPlayerPos(string player)                 | table   | Returns player's position.                            |
 | isPlayerInRange(int range, string username) | boolean | Returns true if the player is in range, false if not. |
-| isPlayersInRange(int range)	 | boolean | Returns true if any player is in range, false if not. |
+| isPlayersInRange(int range)                 | boolean | Returns true if any player is in range, false if not. |
 
 !!! info
-    The center of the range is the Player Detector itself and not the Computer.
+The center of the range is the Player Detector itself and not the Computer.
 
-##Changelog/Trivia
+## Changelog/Trivia
 
 The player detector was also a buggy block, like the energy detector. But it was not too buggy.
 We had bugs that the block uses completely wrong coordinates or the range was broken.

--- a/docs/peripherals/player_detector.md
+++ b/docs/peripherals/player_detector.md
@@ -5,6 +5,8 @@
 
 The Player Detector is able to recognize players within a certain range. In addition, it recognizes the player who clicks on him.
 
+<br><br><br><br><br><br>
+
 ## Overview
 
 | Peripheral Name | Interfaces with | Events | Introduced in |
@@ -17,7 +19,7 @@ The Player Detector is able to recognize players within a certain range. In addi
 | ----------- | ------------- | --------------- | ---------------------------------------- |
 | playerClick | "playerClick" | string username | Fires when a player clicks on the block. |
 
-##Functions
+## Functions
 
 Example:
 
@@ -58,7 +60,7 @@ end
 | isPlayersInRange(int range)                 | boolean | Returns true if any player is in range, false if not. |
 
 !!! info
-The center of the range is the Player Detector itself and not the Computer.
+    The center of the range is the Player Detector itself and not the Computer.
 
 ## Changelog/Trivia
 

--- a/docs/peripherals/redstone_integrator.md
+++ b/docs/peripherals/redstone_integrator.md
@@ -1,4 +1,5 @@
-#Redstone Integrator
+# Redstone Integrator
+
 !!! picture inline end
     ![Header](https://srendi.de/wp-content/uploads/2021/04/Redstone-Integrator.png){ align=right }
 
@@ -7,18 +8,20 @@ You can use the same code you would use for a computer on a Redstone Integrator.
 
 You may need this peripheral for cases where you need to output redstone signals on more sides than a regular computer has to offer.
 
-##Events
-No Events
+## Overview
 
+| Peripheral Name    | Interfaces with | Events | Introduced in |
+| ------------------ | --------------- | ------ | ------------- |
+| redstoneIntegrator | Refined Storage | No     | 0.5.3b        |
 
-##Functions
+## Functions
 
 The Redstone Integrator uses the same sides as the Redstone API.
 You can use `front`, `bottom`, `right` and so on.
 
 You can also use `Analogue` instead of `Analog`. Example: `setAnalogueOutput`
 
-``` lua
+```lua
 integrator = peripheral.wrap("redstoneIntegrator_1") --Defines the Integrator as redstoneIntegrator_1
 
 --Prints some information to the terminal of the computer
@@ -28,17 +31,16 @@ integrator.setOutput("top", true) --Will set the redstone level to 15 at the top
 
 ```
 
-| Function | Returns | Description |
-|----------|---------|-------------|
-|getInput(string direction) |	boolean | Returns true if the redstone at the given side is on. False if not. |
-|getOuput(string direction) |	boolean | Returns true if the Redstone Integrator sends a redstone signal to the given side. False if not. |
-|getAnalogInput(string direction) |	int | Returns the redstone level on the given side. |
-|getAnalogOutput(string direction) |	boolean | Returns the redstone level which sends the Redstone Integrator on the given side. |
-|setOutput(string direction, boolean power) | | Will set the redstone level to 15 on the given side if power is true. |
-|setAnalogOutput(string direction, int power) | | Will set the redstone level to the given power on the given side. |
+| Function                                     | Returns | Description                                                                                      |
+| -------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------ |
+| getInput(string direction)                   | boolean | Returns true if the redstone at the given side is on. False if not.                              |
+| getOuput(string direction)                   | boolean | Returns true if the Redstone Integrator sends a redstone signal to the given side. False if not. |
+| getAnalogInput(string direction)             | int     | Returns the redstone level on the given side.                                                    |
+| getAnalogOutput(string direction)            | boolean | Returns the redstone level which sends the Redstone Integrator on the given side.                |
+| setOutput(string direction, boolean power)   |         | Will set the redstone level to 15 on the given side if power is true.                            |
+| setAnalogOutput(string direction, int power) |         | Will set the redstone level to the given power on the given side.                                |
 
-
-##Changelog/Trivia
+## Changelog/Trivia
 
 0.5.3b
 Added the lovely Redstone Integrator

--- a/docs/peripherals/redstone_integrator.md
+++ b/docs/peripherals/redstone_integrator.md
@@ -22,7 +22,9 @@ You can use `front`, `bottom`, `right` and so on.
 You can also use `Analogue` instead of `Analog`. Example: `setAnalogueOutput`
 
 ```lua
-integrator = peripheral.wrap("redstoneIntegrator_1") --Defines the Integrator as redstoneIntegrator_1
+local integrator = peripheral.find("redstoneIntegrator") -- Finds the peripheral if one is connected
+
+if integrator == nil then error("redstoneIntegrator not found") end
 
 --Prints some information to the terminal of the computer
 print("Left redstone ".. integrator.getAnalogInput("left")) --Will return the level of the redstone at the right side.

--- a/docs/peripherals/rs_bridge.md
+++ b/docs/peripherals/rs_bridge.md
@@ -1,15 +1,20 @@
-#RS Bridge
+# RS Bridge
+
 !!! picture inline end
     ![Header](https://srendi.de/wp-content/uploads/2021/04/RS-Bridge.png){ align=right }
 
 The Rs Bridge is able to interact with Refined Storage.
 You can retrieve items, craft items, get all items as a list and more.
 
-##Events
+<br><br><br><br><br><br>
 
-No events.
+## Overview
 
-##Functions
+| Peripheral Name | Interfaces with | Events | Introduced in |
+| --------------- | --------------- | ------ | ------------- |
+| rsBridge        | Refined Storage | Yes    | 0.3.6b        |
+
+## Functions
 
 Most functions uses a table to craft, export or import the item. You can define NBT values, the amount and the name of the item.
 You can use the command `/advancedperipherals getHashItem` with an item in your hand to get the MD5 hash of the NBT tags of the item. The MD5 hash for the protection I book is `ae70053c97f877de546b0248b9ddf525`.
@@ -23,24 +28,24 @@ bridge.exportItem({name="minecraft:enchanted_book", count=1, nbt="ae70053c97f877
 -- Exports an protection I book to the chest above the me bridge.
 ```
 
-| Function | Returns | Description |
-|----------|---------|-------------|
-| listCraftableFluids() | table | Returns all craftable fluids. |
-| listFluids()	| table | Returns all stored fluids.
-| listCraftableItems() | table |	Returns all craftable items. |
-| listItems() |	table | Returns all items. |
-| isItemCrafting(table item) | boolean | Returns true if a job for the item already exists. |
-| getItem(table item) | table | Returns a table with information of the item. |
-| getEnergyUsage() | int |	Returns the energy usage of the whole RS System. |
-| getEnergyStorage() | int |	Returns the stored energy of the whole RS System. |
-| getMaxEnergyStorage() |	int | Returns the maximum energy storage of the whole RS System. |
-| craftItem(table item)	| table | Crafts an item. |
-| exportItem(table item, string directions) |	int | Exports an item to a chest in the direction of the block. Valid directions are "up", "down", "north", "west", "east" and "south". |
-| importItem(table item, string directions) |	int | Imports an item to the me system from the chest in the direction of the block. Valid directions are "up", "down", "north", "west", "east" and "south". |
-| exportItemToChest(table item, string chest) |	int |	Exports an item to a chest (every inventory tile entity should work) which is connected to the peripheral network. |
-| importItemFromChest(table item, string chest) |	int |	Imports an item to a chest(every inventory tile entity should work) which is connected to the peripheral network. |
+| Function                                      | Returns | Description                                                                                                                                            |
+| --------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| craftItem(table item)                         | table   | Crafts an item.                                                                                                                                        |
+| exportItem(table item, string directions)     | int     | Exports an item to a chest in the direction of the block. Valid directions are "up", "down", "north", "west", "east" and "south".                      |
+| exportItemToChest(table item, string chest)   | int     | Exports an item to a chest (every inventory tile entity should work) which is connected to the peripheral network.                                     |
+| getEnergyStorage()                            | int     | Returns the stored energy of the whole RS System.                                                                                                      |
+| getEnergyUsage()                              | int     | Returns the energy usage of the whole RS System.                                                                                                       |
+| getItem(table item)                           | table   | Returns a table with information of the item.                                                                                                          |
+| getMaxEnergyStorage()                         | int     | Returns the maximum energy storage of the whole RS System.                                                                                             |
+| importItem(table item, string directions)     | int     | Imports an item to the me system from the chest in the direction of the block. Valid directions are "up", "down", "north", "west", "east" and "south". |
+| importItemFromChest(table item, string chest) | int     | Imports an item to a chest(every inventory tile entity should work) which is connected to the peripheral network.                                      |
+| isItemCrafting(table item)                    | boolean | Returns true if a job for the item already exists.                                                                                                     |
+| listCraftableFluids()                         | table   | Returns all craftable fluids.                                                                                                                          |
+| listCraftableItems()                          | table   | Returns all craftable items.                                                                                                                           |
+| listFluids()                                  | table   | Returns all stored fluids.                                                                                                                             |
+| listItems()                                   | table   | Returns all items.                                                                                                                                     |
 
-##Screenshots
+## Screenshots
 
 Picture of the table from listItems()
 
@@ -50,8 +55,7 @@ Picture of the table from listCraftableItems()
 
 ![Picture](https://srendi.de/wp-content/uploads/2021/02/Bild_2021-02-05_234048.png)
 
-
-##Example
+## Example
 
 I made a script to craft items, the computer will re-craft every item needed (a specified amount) in the RS system. Everything is adjustable.
 
@@ -63,7 +67,7 @@ Script: [Click here](https://gist.github.com/Seniorendi/26bd8ecaec400146f2e38790
 Screenshot:
 ![Picture](https://srendi.de/wp-content/uploads/2021/02/Bild_2021-02-05_233915.png)
 
-##Changelog/Trivia
+## Changelog/Trivia
 
 0.4b
 Reworked the system of the RS Bridge, it has now more features and a new system for the item parameter.

--- a/docs/peripherals/rs_bridge.md
+++ b/docs/peripherals/rs_bridge.md
@@ -22,7 +22,9 @@ You can use the command `/advancedperipherals getHashItem` with an item in your 
 Example with exportItem:
 
 ```lua
-bridge = peripheral.wrap("rsBridge_0") -- Define the peripheral
+local bridge = peripheral.find("rsBridge") -- Finds the peripheral if one is connected
+
+if bridge == nil then error("rsBridge not found") end
 
 bridge.exportItem({name="minecraft:enchanted_book", count=1, nbt="ae70053c97f877de546b0248b9ddf525"}, "UP")
 -- Exports an protection I book to the chest above the me bridge.


### PR DESCRIPTION
- added the overview section to the remaining peripheral pages
- changed example scripts to use `local` and replaced `peripheral.wrap(SIDE)` with `peripheral.find()`
- added `if`-block to check if peripheral was found to make examples a more convenient starting point
- tried to improve formatting of markdown source (e.g. tables)