### PR TITLE
Fixed incorrect links

### DIFF
--- a/docs/metaphysics/end_automata.md
+++ b/docs/metaphysics/end_automata.md
@@ -5,7 +5,7 @@
 
 The end automata is turtle with End Mechanic Soul upgrade!
 
-This upgrade allow everything, that [Weak automata](https://docs.srendi.de/turtles/weak_automata/) does and also provide ability to teleport to stored positions by marks! But this upgrade only works in one dimension now.
+This upgrade allow everything, that [Weak automata](https://docs.srendi.de/metaphysics/weak_automata/) does and also provide ability to teleport to stored positions by marks! But this upgrade only works in one dimension now.
 
 ## Overview
 

--- a/docs/metaphysics/husbandry_automata.md
+++ b/docs/metaphysics/husbandry_automata.md
@@ -5,7 +5,7 @@
 
 The husbandry automata is turtle with Husbandry Mechanic Soul upgrade!
 
-This upgrade allow everything, that [Weak automata](https://docs.srendi.de/turtles/weak_automata/) does and also provide ability interact with animals and even capture it.
+This upgrade allow everything, that [Weak automata](https://docs.srendi.de/metaphysics/weak_automata/) does and also provide ability interact with animals and even capture it.
 
 ## Overview
 


### PR DESCRIPTION
For some reason the weak_automata is referenced to be under the turtles directory when it resides in metaphysics.

Perhaps the solution should be to move the weak_automata documentation to be inside of turtles, but I think its fine where it is as long as the links work for those trying to use said documentation.