### PR TITLE
fix colony_integrator.md getBuilderResources description

### DIFF
--- a/docs/1.18/peripherals/colony_integrator.md
+++ b/docs/1.18/peripherals/colony_integrator.md
@@ -53,7 +53,7 @@ end
 | getResearch()                   | table   | Returns all possible researches, currently researches that is being worked on and research that has already been researched. |
 | getWorkOrderResources(int id)   | table   | Returns a table with the resources of a work order. You can find out every order and its ID with getWorkOrders().                         |
 | getRequests()                   | table   | Returns all requests in any kind of the colony. |
-| getBuilderResources(table position) | table   | Returns all resources of the given builder's hut.                       |
+| getBuilderResources(table position) | table   | Returns the required resources of the given builder's hut.             |
 
 ## Examples
 


### PR DESCRIPTION
Description suggested it lists all resources but it only lists required resources for the current build.

Steps to validate:
Start a build
add an item to the builder's hut that is not related to the build (eg: a diamond)
execute method
unrelated item will not be listed
