### PR TITLE
Update README and match requirements.txt to pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,15 @@
 # Advanced Peripherals Documentation
 
-![Website](https://img.shields.io/website?down_color=red&down_message=offline&label=Netify%28Host%29&style=for-the-badge&up_color=green&up_message=online&url=https%3A%2F%2Fadvancedperipherals.netlify.app)
+<center>
 
-This is the source of the documentation for Advanced Peripherals.
-The documentation is built with [mkdocs](https://www.mkdocs.org). 
+[![Project](https://img.shields.io/badge/Project-2E9CFF?style=for-the-badge&logoColor=white&logo=Github)](https://github.com/SirEndii/AdvancedPeripherals)
+![Netlify Status](https://img.shields.io/website?down_color=red&down_message=offline&label=Netlify%28Host%29&style=for-the-badge&up_color=green&up_message=online&url=https%3A%2F%2Fadvancedperipherals.netlify.app&logoColor=white&logo=Netlify)
+[![Discord](https://img.shields.io/discord/734726882058174486?label=Discord&style=for-the-badge&color=7289da&logoColor=white&logo=Discord)](https://discord.intelligence-modding.de/)
+
+</center>
+
+This is the source of the documentation for Advanced Peripherals.  
+The documentation is built with [mkdocs](https://www.mkdocs.org).  
 I recommend using mkdocs if you want to contribute, but you do not need to.
 
 ## Site

--- a/README.md
+++ b/README.md
@@ -26,3 +26,17 @@ Once dependencies have been installed you can now serve with mkdocs to view your
 poetry run mkdocs serve
 ~~~
 Click the url in your terminal to open the docs in your browser.
+
+## Setup with Pip
+If you have python installed on your machine you will have pip installed.
+Install the necessary dependencies by running:
+~~~zsh
+pip install -r requirements.txt
+~~~
+:warning: *Make sure you are in the folder with the `requirements.txt` file*
+
+Once dependencies have been installed you can now serve with mkdocs to view your changes:
+~~~zsh
+python -m mkdocs serve
+~~~
+Click the url in your terminal to open the docs in your browser.

--- a/README.md
+++ b/README.md
@@ -6,8 +6,11 @@ This is the source of the documentation for Advanced Peripherals.
 The documentation is built with [mkdocs](https://www.mkdocs.org). 
 I recommend using mkdocs if you want to contribute, but you do not need to.
 
-Web: https://docs.intelligence-modding.de/
-Alternative: https://peaceful-nobel-03befe.netlify.app/
+## Site
+The docs can be viewed at any of the below:  
+https://docs.intelligence-modding.de/  
+https://advancedperipherals.madefor.cc/  
+https://advancedperipherals.netlify.app/  
 
 # Contributing
 
@@ -27,8 +30,10 @@ poetry run mkdocs serve
 ~~~
 Click the url in your terminal to open the docs in your browser.
 
+---
+
 ## Setup with Pip
-If you have python installed on your machine you will have pip installed.
+If you have python installed on your machine you will have pip installed.  
 Install the necessary dependencies by running:
 ~~~zsh
 pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
+mkdocs
+mkdocs-material
 lightgallery
 python-markdown-math


### PR DESCRIPTION
Added an alternative setup guide which is just for pip and python alone. Added the madefor.cc domain to site list and added discord and project github shields.