### PR TITLE
Fix typo in environment_detector.md

### DIFF
--- a/docs/peripherals/environment_detector.md
+++ b/docs/peripherals/environment_detector.md
@@ -166,7 +166,7 @@ Returns the current radiation level from the Mekanism mod with the radiation uni
 ### getRadiationRaw
 
 ```
-getRatiationRaw() -> number
+getRadiationRaw() -> number
 ```
 
 !!! success "Added in version 0.6.5b"


### PR DESCRIPTION
Fixed a typo “getRatiationRaw” -> “getRadiationRaw”