### PR TITLE
Fix header for Mekanism Digital Miner

### DIFF
--- a/docs/integrations/mekanism/digital_miner.md
+++ b/docs/integrations/mekanism/digital_miner.md
@@ -1,6 +1,6 @@
 <h4><a href="../">Go Back</a></h4>
 
-# Fission Reactor
+# Digital Miner
 
 !!! picture inline end
     ![Header](https://intelligence-modding.de/wp-content/uploads/2021/05/Digital-Miner.png){ align=right }


### PR DESCRIPTION
Minor change. The header for the Mekanism Digital Miner is set to "Fission Reactor", which is a different thing.