### PR TITLE
Remove wrong import/export warning from the NBT Storage page

### DIFF
--- a/docs/peripherals/nbt_storage.md
+++ b/docs/peripherals/nbt_storage.md
@@ -19,10 +19,6 @@ NBT Storage is a custom block that allows reading and writing of NBT data to the
 
 ---
 
-!!! failure
-    <center> <h3> You need to place the inventory/tank you want to use to export/import stuff next to the RS Bridge and **NOT** next to the computer! <h3> </center>
-
-
 ## Functions
 
 ### read


### PR DESCRIPTION
This was introduced in 5444c20 with a text referring to the RS Bridge but on the wrong page.
(the text was later added to the RS Bridge page in de889f7 but not removed here)