### PR TITLE
Geo Scanner - Fix method name for getMaxFuelLevel

### DIFF
--- a/docs/peripherals/geo_scanner.md
+++ b/docs/peripherals/geo_scanner.md
@@ -32,9 +32,9 @@ Returns the amount of stored fuel.
 
 ---
 
-### getFuelMaxLevel
+### getMaxFuelLevel
 ```
-getFuelMaxLevel() -> number
+getMaxFuelLevel() -> number
 ```
 
 Returns the maximum amount of possible stored fuel.


### PR DESCRIPTION
The Geo Scanner docs currently list the method `getFuelMaxLevel` which doesn't exist. It is actually called `getMaxFuelLevel` (see https://github.com/IntelligenceModding/AdvancedPeripherals/blob/741ee239db898eea82ad87849f6195b4b19ec0c3/src/main/java/de/srendi/advancedperipherals/common/addons/computercraft/owner/FuelAbility.java#L79)