### PR TITLE
Powah: Remove duplicate getMaxEnergy entry on Reactor

### DIFF
--- a/docs/integrations/powah/reactor.md
+++ b/docs/integrations/powah/reactor.md
@@ -47,8 +47,6 @@ Returns the maximum quantity of storable energy inside the Reactor.
 
 ---
 
----
-
 ### isRunning
 ```
 isRunning() -> boolean

--- a/docs/integrations/powah/reactor.md
+++ b/docs/integrations/powah/reactor.md
@@ -47,12 +47,6 @@ Returns the maximum quantity of storable energy inside the Reactor.
 
 ---
 
-### getMaxEnergy
-```
-getMaxEnergy() -> number
-```
-Returns the maximum quantity of storable energy inside the Reactor.
-
 ---
 
 ### isRunning


### PR DESCRIPTION
Fixes this issue in current docs (https://docs.advanced-peripherals.de/integrations/powah/reactor/):

![image](https://github.com/user-attachments/assets/3c5b9876-fa04-419d-94ec-2de6c7af3320)
