### PR TITLE
changed older to newer mistypo

### DIFF
--- a/docs/peripherals/me_bridge.md
+++ b/docs/peripherals/me_bridge.md
@@ -33,7 +33,7 @@ You can retrieve items, craft items, get all items as a list and more. The ME Br
 === "1.20.1-0.7 and older"
 
     !!! info
-        If you are playing on 0.7 for the minecraft version 1.21.1 and older, please use the content tab for "1.21.1-0.7 and newer".
+        If you are playing on 0.7 for the minecraft version 1.21.1 and newer, please use the content tab for "1.21.1-0.7 and newer".
         The following documentation contains the legacy ME and RS bridge features which will be replaced with the next stable AP version.
 
         The new ME and RS Bridge systems will eventually be back ported to 1.20.1 and 1.19.2 with 0.8.

--- a/docs/peripherals/rs_bridge.md
+++ b/docs/peripherals/rs_bridge.md
@@ -33,7 +33,7 @@ You can retrieve items, craft items, get all items as a list and more.
 === "1.20.1-0.7 and older"
 
     !!! info
-        If you are playing on 0.7 for the minecraft version 1.21.1 and older, please use the content tab for "1.21.1-0.7 and newer".
+        If you are playing on 0.7 for the minecraft version 1.21.1 and newer, please use the content tab for "1.21.1-0.7 and newer".
         The following documentation contains the legacy ME and RS bridge features which will be replaced with the next stable AP version.
 
         The newer ME and RS Bridge system will eventually be back ported to 1.20.1 and 1.19.2 with 0.8.


### PR DESCRIPTION
In the "1.20.1-0.7 and older" tab, the info tag seemed misleading. I changed it to be consistent with the tab names. I'm not 100% sure if it's intended though, so feel free to reject.